### PR TITLE
Show clearer timestamp string in logs

### DIFF
--- a/code/AdobeEdge.brs
+++ b/code/AdobeEdge.brs
@@ -762,7 +762,7 @@ function _adb_serviceProvider() as object
                     ' else
                     '     print message
                     ' end if
-                    print "[" + _adb_ISO8601_timestamp() + "]" + message
+                    print "[" + _adb_ISO8601_timestamp().Replace("T", " ") + "]" + message
 
                 end function
             },


### PR DESCRIPTION
```txt
[2023-06-28 18:50:07Z][ADB-EDGE][I] start the event loop
[2023-06-28 18:50:07Z][ADB-EDGE][I] handleEvent() - handle event: {"apiname":"setLogLevel","data":{"level":0},"owner":"adobe","timestamp":"2023-06-28T18:50:07Z","timestamp_in_millis":2147483647,"uuid":"4cd997c7-46f3-4fa4-a92f-d9be549e63b7"}
[2023-06-28 18:50:07Z][ADB-EDGE][I] _setLogLevel() - set log level: 0
```