### PR TITLE
Added logic to wait before retrying requests failed with recoverable error

### DIFF
--- a/code/main/core/identityModule.brs
+++ b/code/main/core/identityModule.brs
@@ -41,7 +41,7 @@ function _adb_IdentityModule(configurationModule as object) as object
                 m.updateECID(m._queryECID())
             end if
 
-            _adb_logDebug("getECID() - Returning ECID:(" + FormatJson(m._ecid) + ")")
+            _adb_logVerbose("getECID() - Returning ECID:(" + FormatJson(m._ecid) + ")")
             return m._ecid
         end function,
 
@@ -58,7 +58,7 @@ function _adb_IdentityModule(configurationModule as object) as object
         end function,
 
         _loadECID: function() as dynamic
-            _adb_logInfo("_loadECID() - Loading ECID from persistence.")
+            _adb_logVerbose("_loadECID() - Loading ECID from persistence.")
             localDataStoreService = _adb_serviceProvider().localDataStoreService
             ecid = localDataStoreService.readValue(_adb_InternalConstants().LOCAL_DATA_STORE_KEYS.ECID)
 
@@ -72,7 +72,7 @@ function _adb_IdentityModule(configurationModule as object) as object
         end function,
 
         _deleteECID: function() as void
-            _adb_logDebug("_deleteECID() - Removing ECID from persistence.")
+            _adb_logVerbose("_deleteECID() - Removing ECID from persistence.")
             localDataStoreService = _adb_serviceProvider().localDataStoreService
             localDataStoreService.removeValue(_adb_InternalConstants().LOCAL_DATA_STORE_KEYS.ECID)
             return

--- a/code/main/edge/edgeRequestWorker.brs
+++ b/code/main/edge/edgeRequestWorker.brs
@@ -47,6 +47,9 @@ function _adb_EdgeRequestWorker() as object
                 m._queue.Shift()
             end if
             m._queue.Push(requestEntity)
+
+            ''' force retry the hits by disabling wait
+            m._lastFailedRequestTS = m._INVALID_WAIT_TIME
         end function,
 
         hasQueuedEvent: function() as boolean

--- a/code/main/edge/edgeRequestWorker.brs
+++ b/code/main/edge/edgeRequestWorker.brs
@@ -15,7 +15,7 @@
 
 function _adb_EdgeRequestWorker() as object
     instance = {
-        _RETRY_WAIT_TIME: 5000, ' 5 seconds
+        _RETRY_WAIT_TIME_MS: 30000, ' 30 seconds
         _INVALID_WAIT_TIME: -1,
         _lastFailedRequestTS: -1,
         _queue: [],
@@ -63,8 +63,8 @@ function _adb_EdgeRequestWorker() as object
             while m.hasQueuedEvent()
 
                 currTS = _adb_timestampInMillis()
-                if (m._lastFailedRequestTS <> m._INVALID_WAIT_TIME) and ((currTS - m._lastFailedRequestTS) < m._RETRY_WAIT_TIME)
-                    ' Wait for 5 seconds before retrying the hit failed with recoverable error.
+                if (m._lastFailedRequestTS <> m._INVALID_WAIT_TIME) and ((currTS - m._lastFailedRequestTS) < m._RETRY_WAIT_TIME_MS)
+                    ' Wait for 30 seconds before retrying the hit failed with recoverable error.
                     exit while
                 end if
 
@@ -90,7 +90,7 @@ function _adb_EdgeRequestWorker() as object
                     m._lastFailedRequestTS = m._INVALID_WAIT_TIME
                 else if networkResponse.isRecoverable()
                     m._lastFailedRequestTS = _adb_timestampInMillis()
-                    _adb_logError("processRequests() - Edge request failed with recoverable error:(" + networkResponse.getResponseString() + "). Request will be retried.")
+                    _adb_logWarning("processRequests() - Edge request with id:(" + FormatJson(requestId)  + ") failed with recoverable error code:(" + FormatJson(networkResponse.getResponseCode()) + "). Request will be retried after (" + FormatJson(m._RETRY_WAIT_TIME_MS) + ") ms.")
                     m._queue.Unshift(requestEntity)
                     exit while
                 end if

--- a/code/main/services/networkResponse.brs
+++ b/code/main/services/networkResponse.brs
@@ -29,18 +29,12 @@ function _adb_NetworkResponse(responseCode as integer, responseBody as string) a
 
         isSuccessful: function() as boolean
             ' https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses
-            if m._responseCode >= 200 and m._responseCode < 300 then
-                return true
-            end if
-            return false
+            return m._responseCode >= 200 and m._responseCode < 300
         end function,
 
         isRecoverable: function() as boolean
             ' RECOVERABLE_ERROR_CODES = [408, 504, 503]
-            if m._responseCode = 408 or m._responseCode = 504 or m._responseCode = 503 then
-                return true
-            end if
-            return false
+            return  m._responseCode = 408 or m._responseCode = 504 or m._responseCode = 503
         end function,
 
         toString: function() as String

--- a/code/main/services/networkService.brs
+++ b/code/main/services/networkService.brs
@@ -62,7 +62,7 @@ function _adb_NetworkService() as object
         end sub,
 
         _syncPostRequest: function(url as string, jsonObj as object, headers = [] as dynamic) as object
-            _adb_logVerbose("syncPostRequest() - Attempting to send request with url:(" + FormatJson(url) + ") and body:(" + FormatJson(jsonObj) + ").")
+            _adb_logDebug("syncPostRequest() - Attempting to send request with url:(" + FormatJson(url) + ") and body:(" + FormatJson(jsonObj) + ").")
 
             request = CreateObject("roUrlTransfer")
             port = CreateObject("roMessagePort")

--- a/code/main/task/eventProcessor.brs
+++ b/code/main/task/eventProcessor.brs
@@ -63,6 +63,7 @@ function _adb_EventProcessor(task as object) as object
         _dumpDebugInfo: function(event as object, loggingService as object, networkService as object) as void
             debugInfo = {
                 eventId: event.uuid,
+                eventData: event.data,
                 apiName: event.apiName
             }
 

--- a/code/tests/test_helper.brs
+++ b/code/tests/test_helper.brs
@@ -48,3 +48,10 @@ function isEmptyOrInvalidString(str as dynamic) as boolean
 
     return false
 end function
+
+
+' ************************ Wait Timer Helper ************************
+function _adb_waitFor(time = 1 as integer)
+    port = CreateObject("roMessagePort")
+    msg = wait(time, port)
+end function

--- a/code/tests/test_helper.brs
+++ b/code/tests/test_helper.brs
@@ -48,10 +48,3 @@ function isEmptyOrInvalidString(str as dynamic) as boolean
 
     return false
 end function
-
-
-' ************************ Wait Timer Helper ************************
-function _adb_waitFor(time = 1 as integer)
-    port = CreateObject("roMessagePort")
-    msg = wait(time, port)
-end function

--- a/sample/development/components/integration/test/integrationTests.brs
+++ b/sample/development/components/integration/test/integrationTests.brs
@@ -14,6 +14,7 @@
 function TS_SDK_integration() as object
     instance = {
 
+        _testECID: "12345678901234567890123456789012345678",
         configId: invalid,
 
         init: sub()
@@ -70,26 +71,6 @@ function TS_SDK_integration() as object
             return validator
         end function,
 
-        TC_SDK_setLogLevel_info: function() as dynamic
-
-            adobeEdgeSdk = ADB_retrieveSDKInstance()
-
-            ADB_CONSTANTS = AdobeSDKConstants()
-            adobeEdgeSdk.setLogLevel(ADB_CONSTANTS.LOG_LEVEL.INFO)
-            adobeEdgeSdk.setLogLevel(ADB_CONSTANTS.LOG_LEVEL.DEBUG)
-            adobeEdgeSdk.setLogLevel(ADB_CONSTANTS.LOG_LEVEL.INFO)
-
-            eventIdForSetLogLevel = adobeEdgeSdk._private.lastEventId
-            validator = {}
-            validator[eventIdForSetLogLevel] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setLogLevel"), LINE_NUM, "assert debugInfo.apiName = setLogLevel")
-                ADB_assertTrue((debugInfo.loglevel <> invalid and debugInfo.loglevel = 2), LINE_NUM, " assert  debugInfo.loglevel = 2")
-            end sub
-
-            return validator
-        end function,
-
         TC_SDK_resetIdentities: function() as dynamic
 
             adobeEdgeSdk = ADB_retrieveSDKInstance()
@@ -115,36 +96,17 @@ function TS_SDK_integration() as object
             return validator
         end function,
 
-        TC_SDK_resetIdentities_withoutValidECID: function() as dynamic
-
-            adobeEdgeSdk = ADB_retrieveSDKInstance()
-
-            adobeEdgeSdk.resetIdentities()
-            eventIdForResetIdentities = adobeEdgeSdk._private.lastEventId
-            validator = {}
-            validator[eventIdForResetIdentities] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "resetIdentities"), LINE_NUM, "assert debugInfo.apiName = resetIdentities")
-                ADB_assertTrue((debugInfo.identity.ecid = invalid), LINE_NUM, "assert ecid is invalid")
-                ecidInRegistry = ADB_getPersistedECID()
-                ADB_assertTrue((ecidInRegistry = invalid), LINE_NUM, "assert the persisted ecid is invalid")
-            end sub
-
-            return validator
-        end function,
-
         TC_SDK_updateConfiguration: function() as dynamic
 
             adobeEdgeSdk = ADB_retrieveSDKInstance()
 
             adobeEdgeSdk.updateConfiguration({
                 "edge.configId": "test_configId_1",
-                "edge.domain": "",
             })
             eventIdForUpdateConfiguration1 = adobeEdgeSdk._private.lastEventId
             adobeEdgeSdk.updateConfiguration({
                 "edge.configId": "test_configId_2",
-                "edge.domain": "",
+                "edge.domain": "edge.com",
             })
             eventIdForUpdateConfiguration2 = adobeEdgeSdk._private.lastEventId
             validator = {}
@@ -158,67 +120,7 @@ function TS_SDK_integration() as object
                 ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
                 ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setConfiguration"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
                 ADB_assertTrue((debugInfo.configuration.edge_configid = "test_configId_2"), LINE_NUM, "assert edge_configid is test_configId_2")
-                ADB_assertTrue((debugInfo.configuration.edge_domain = invalid), LINE_NUM, "assert edge_domain is invalid")
-            end sub
-
-            return validator
-        end function,
-
-        TC_SDK_updateConfiguration_seperateKey: function() as dynamic
-
-            adobeEdgeSdk = ADB_retrieveSDKInstance()
-
-            adobeEdgeSdk.updateConfiguration({
-                "edge.configId": "test_configId_1",
-                "edge.domain": "",
-            })
-            eventIdForUpdateConfiguration1 = adobeEdgeSdk._private.lastEventId
-            adobeEdgeSdk.updateConfiguration({
-                "edge.configId": "test_configId_2",
-            })
-            eventIdForUpdateConfiguration2 = adobeEdgeSdk._private.lastEventId
-            validator = {}
-            validator[eventIdForUpdateConfiguration1] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setConfiguration"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
-                ADB_assertTrue((debugInfo.configuration.edge_configid = "test_configId_1"), LINE_NUM, "assert edge_configid is test_configId_1")
-                ADB_assertTrue((debugInfo.configuration.edge_domain = invalid), LINE_NUM, "assert edge_domain is invalid")
-            end sub
-            validator[eventIdForUpdateConfiguration2] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setConfiguration"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
-                ADB_assertTrue((debugInfo.configuration.edge_configid = "test_configId_2"), LINE_NUM, "assert edge_configid is test_configId_2")
-                ADB_assertTrue((debugInfo.configuration.edge_domain = invalid), LINE_NUM, "assert edge_domain is invalid")
-            end sub
-
-            return validator
-        end function,
-
-        TC_SDK_updateConfiguration_wrongKey: function() as dynamic
-
-            adobeEdgeSdk = ADB_retrieveSDKInstance()
-
-            adobeEdgeSdk.updateConfiguration({
-                "edge.configId": "test_configId_1",
-                "edge.domain": "",
-            })
-            eventIdForUpdateConfiguration1 = adobeEdgeSdk._private.lastEventId
-            adobeEdgeSdk.updateConfiguration({
-                "bad.key.edge.configId": "test_configId_2",
-            })
-            eventIdForUpdateConfiguration2 = adobeEdgeSdk._private.lastEventId
-            validator = {}
-            validator[eventIdForUpdateConfiguration1] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setConfiguration"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
-                ADB_assertTrue((debugInfo.configuration.edge_configid = "test_configId_1"), LINE_NUM, "assert edge_configid is test_configId_1")
-                ADB_assertTrue((debugInfo.configuration.edge_domain = invalid), LINE_NUM, "assert edge_domain is invalid")
-            end sub
-            validator[eventIdForUpdateConfiguration2] = sub(debugInfo)
-                ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
-                ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setConfiguration"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
-                ADB_assertTrue((debugInfo.configuration.edge_configid = "test_configId_1"), LINE_NUM, "assert edge_configid is test_configId_1")
-                ADB_assertTrue((debugInfo.configuration.edge_domain = invalid), LINE_NUM, "assert edge_domain is invalid")
+                ADB_assertTrue((debugInfo.configuration.edge_domain = "edge.com"), LINE_NUM, "Expected: (edge.com) != Actual: (" + debugInfo.configuration.edge_domain + ")")
             end sub
 
             return validator
@@ -283,13 +185,16 @@ function TS_SDK_integration() as object
                 expectedXDMDataJson = FormatJson(expectedXDMData)
                 ADB_assertTrue((xdmDataJson = expectedXDMDataJson), LINE_NUM, "Actual XDM data(" + xdmDataJson + ") != Expected XDM data(" + expectedXDMDataJson + ") ")
 
+                ' Verify fetch ECID request
                 ADB_assertTrue((debugInfo.networkRequests <> invalid and debugInfo.networkRequests.count() = 2), LINE_NUM, "assert networkRequests = 2")
                 ADB_assertTrue((debugInfo.networkRequests[0].jsonObj.events[0].query.identity.fetch[0] = "ECID"), LINE_NUM, "assert networkRequests(1) is to fetch ECID")
                 ADB_assertTrue((debugInfo.networkRequests[0].response.code = 200), LINE_NUM, "assert response (1) returns 200")
                 firstResponseJson = ParseJson(debugInfo.networkRequests[0].response.body)
-                ADB_assertTrue((firstResponseJson.handle[0].payload[0].id = ecid), LINE_NUM, "assert response (1) verify ECID")
+                ADB_assertTrue((firstResponseJson.handle[0].payload[0].id <> invalid), LINE_NUM, "ECID should not be invalid")
+                ADB_assertTrue((firstResponseJson.handle[0].payload[0].id = ecid), LINE_NUM, "Expected: (" + ecid + ") != Actual: (" + firstResponseJson.handle[0].payload[0].id + ")")
                 ADB_assertTrue((firstResponseJson.requestId <> eventid), LINE_NUM, "assert response (1) verify request ID")
 
+                ' Verify XDM data
                 ADB_assertTrue((debugInfo.networkRequests[1].jsonObj.events[0].xdm.key = "value"), LINE_NUM, "assert networkRequests(2) is to send Edge event")
                 ADB_assertTrue((Len(debugInfo.networkRequests[1].jsonObj.events[0].xdm.timestamp) > 10), LINE_NUM, "assert networkRequests(2) is to send Edge event with timestamp")
                 ADB_assertTrue((debugInfo.networkRequests[1].jsonObj.xdm.identityMap.ECID <> invalid), LINE_NUM, "assert networkRequests(2) is to send Edge event with ecid")
@@ -474,7 +379,7 @@ function TS_SDK_integration() as object
 
             adobeEdgeSdk = ADB_retrieveSDKInstance()
 
-            adobeEdgeSdk.setExperienceCloudId("test_ecid")
+            adobeEdgeSdk.setExperienceCloudId(m._testECID)
             eventIdForSetExperienceCloudId = adobeEdgeSdk._private.lastEventId
 
             ADB_CONSTANTS = AdobeSDKConstants()
@@ -494,7 +399,7 @@ function TS_SDK_integration() as object
                 ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
                 ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "setExperienceCloudId"), LINE_NUM, "assert debugInfo.apiName = setConfiguration")
                 ecidInRegistry = ADB_getPersistedECID()
-                ADB_assertTrue((ecidInRegistry = "test_ecid"), LINE_NUM, "assert test_ecid is persisted in Registry")
+                ADB_assertTrue((ecidInRegistry = "12345678901234567890123456789012345678"), LINE_NUM, "assert ECID is persisted in Registry")
             end sub
             validator[eventIdForUpdateConfiguration] = sub(debugInfo)
                 ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
@@ -505,16 +410,16 @@ function TS_SDK_integration() as object
             validator[eventIdForSendEvent] = sub(debugInfo)
                 ' _adb_logInfo("start to validate setLogLevel operation with debugInfo: " + FormatJson(debugInfo))
                 ecid = debugInfo.identity.ecid
-                ADB_assertTrue((ecid = "test_ecid"), LINE_NUM, "assert debugInfo.identity.ecid = test_ecid")
+                ADB_assertTrue((ecid = "12345678901234567890123456789012345678"), LINE_NUM, "assert debugInfo.identity.ecid = 12345678901234567890123456789012345678")
                 eventid = debugInfo.eventid
                 ADB_assertTrue((debugInfo <> invalid and debugInfo.apiName = "sendEvent"), LINE_NUM, "assert debugInfo.apiName = sendEvent")
                 ADB_assertTrue((debugInfo.networkRequests <> invalid and debugInfo.networkRequests.count() = 1), LINE_NUM, "assert networkRequests = 1")
 
                 ADB_assertTrue((debugInfo.networkRequests[0].jsonObj.events[0].xdm.key = "value"), LINE_NUM, "assert networkRequests(1) is to send Edge event")
-                ADB_assertTrue((debugInfo.networkRequests[0].response.code = 400), LINE_NUM, "assert response (1) returns 200")
+                ADB_assertTrue((debugInfo.networkRequests[0].response.code = 200), LINE_NUM, "assert response (1) returns 200")
 
                 ecidInRegistry = ADB_getPersistedECID()
-                ADB_assertTrue((ecidInRegistry = "test_ecid"), LINE_NUM, "assert test_ecid is persisted in Registry")
+                ADB_assertTrue((ecidInRegistry = "12345678901234567890123456789012345678"), LINE_NUM, "assert 12345678901234567890123456789012345678 is persisted in Registry")
             end sub
 
             return validator
@@ -522,7 +427,7 @@ function TS_SDK_integration() as object
 
         TC_SDK_ecid_consistence: function() as dynamic
 
-            ADB_persisteECIDInRegistry("test_ecid_x")
+            ADB_persisteECIDInRegistry(m._testECID)
 
             adobeEdgeSdk = ADB_retrieveSDKInstance()
 
@@ -547,7 +452,7 @@ function TS_SDK_integration() as object
                 ADB_assertTrue((debugInfo.configuration.edge_configid <> invalid and Len(debugInfo.configuration.edge_configid) > 10), LINE_NUM, "assert edge_configid is valid")
 
                 ecidInRegistry = ADB_getPersistedECID()
-                ADB_assertTrue((ecidInRegistry = "test_ecid_x"), LINE_NUM, "assert test_ecid_x is persisted in Registry")
+                ADB_assertTrue((ecidInRegistry = "12345678901234567890123456789012345678"), LINE_NUM, "assert ECID is persisted in Registry")
             end sub
 
             validator[eventIdForSendEvent] = sub(debugInfo)
@@ -558,12 +463,12 @@ function TS_SDK_integration() as object
                 ADB_assertTrue((debugInfo.networkRequests <> invalid and debugInfo.networkRequests.count() = 1), LINE_NUM, "assert networkRequests = 1")
 
                 ADB_assertTrue((debugInfo.networkRequests[0].jsonObj.events[0].xdm.key = "value"), LINE_NUM, "assert networkRequests(1) is to send Edge event")
-                ADB_assertTrue((debugInfo.networkRequests[0].response.code = 400), LINE_NUM, "assert response (1) returns 200")
+                ADB_assertTrue((debugInfo.networkRequests[0].response.code = 200), LINE_NUM, "assert response (1) returns 200")
 
                 ecidInRegistry = ADB_getPersistedECID()
                 ecid = debugInfo.identity.ecid
-                ADB_assertTrue((ecid = "test_ecid_x"), LINE_NUM, "assert in-memory ecid is test_ecid_x")
-                ADB_assertTrue((ecidInRegistry = "test_ecid_x"), LINE_NUM, "assert test_ecid_x is persisted in Registry")
+                ADB_assertTrue((ecid = "12345678901234567890123456789012345678"), LINE_NUM, "assert in-memory ECID is 12345678901234567890123456789012345678")
+                ADB_assertTrue((ecidInRegistry = "12345678901234567890123456789012345678"), LINE_NUM, "assert persisted ECID is 12345678901234567890123456789012345678")
             end sub
 
             return validator

--- a/sample/development/source/setup_tests.brs
+++ b/sample/development/source/setup_tests.brs
@@ -108,7 +108,8 @@ function _adb_test_functions() as dynamic
         TC_adb_EdgeRequestWorker_processRequest_invalid_response
         TC_adb_EdgeRequestWorker_processRequests
         TC_adb_EdgeRequestWorker_processRequests_empty_queue
-        TC_adb_EdgeRequestWorker_processRequests_recoverable_error
+        TC_adb_EdgeRequestWorker_processRequests_recoverableError_retriesAfterWaitTimeout
+        TC_adb_EdgeRequestWorker_queue_newRequest_after_RecoverableError_retriesImmediately
         'test_edgeModule.brs
         TC_adb_EdgeModule_init
         TC_adb_EdgeModule_processEvent


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added logic to wait 5 seconds before retrying request failed with recoverable error
- Refactored code

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2023-07-28 at 1 02 06 PM](https://github.com/adobe/aepsdk-roku/assets/4697559/7bff473b-d912-422f-b66c-ca60ac137867)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
