### PR TITLE
Revert registry changes to avoid breaking changes

### DIFF
--- a/code/main/services/localDataStoreService.brs
+++ b/code/main/services/localDataStoreService.brs
@@ -17,7 +17,7 @@ function _adb_LocalDataStoreService() as object
     return {
 
         ''' private internal variables
-        _registry: CreateObject("roRegistrySection", "adb_aep_roku_sdk"),
+        _registry: CreateObject("roRegistrySection", "adb_edge_mobile"),
 
         ''' public Functions
         writeValue: function(key as string, value as string) as void

--- a/code/tests/test_helper.brs
+++ b/code/tests/test_helper.brs
@@ -22,13 +22,13 @@ function getPersistedECID() as dynamic
 end function
 
 function removeValue(key) as void
-    _registry = CreateObject("roRegistrySection", "adb_aep_roku_sdk")
+    _registry = CreateObject("roRegistrySection", "adb_edge_mobile")
     _registry.Delete(key)
     _registry.Flush()
 end function
 
 function readValueFromRegistry(key as string) as dynamic
-    _registry = CreateObject("roRegistrySection", "adb_aep_roku_sdk")
+    _registry = CreateObject("roRegistrySection", "adb_edge_mobile")
     if _registry.Exists(key) and _registry.Read(key).Len() > 0
         return _registry.Read(key)
     end if

--- a/sample/development/components/integration/scene/ADBTestRunner.brs
+++ b/sample/development/components/integration/scene/ADBTestRunner.brs
@@ -253,7 +253,7 @@ sub ADB_resetSDK(instance as object)
 end sub
 
 function ADB_removeRegistryValue(key) as void
-    _registry = CreateObject("roRegistrySection", "adb_aep_roku_sdk")
+    _registry = CreateObject("roRegistrySection", "adb_edge_mobile")
     _registry.Delete(key)
     _registry.Flush()
 end function
@@ -268,7 +268,7 @@ function ADB_getPersistedECID() as dynamic
 end function
 
 function ADB_readRegistryValue(key as string) as dynamic
-    _registry = CreateObject("roRegistrySection", "adb_aep_roku_sdk")
+    _registry = CreateObject("roRegistrySection", "adb_edge_mobile")
     if _registry.Exists(key) and _registry.Read(key).Len() > 0
         return _registry.Read(key)
     end if
@@ -277,7 +277,7 @@ function ADB_readRegistryValue(key as string) as dynamic
 end function
 
 function ADB_persisteECIDInRegistry(value as string) as dynamic
-    _registry = CreateObject("roRegistrySection", "adb_aep_roku_sdk")
+    _registry = CreateObject("roRegistrySection", "adb_edge_mobile")
     _registry.Write("ecid", value)
     return invalid
 end function


### PR DESCRIPTION
We need to revert the name change in the Roku registry as it may have an impact on alpha users.