### PR TITLE
Add Free form data support in SendEvent API

### DIFF
--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -131,7 +131,7 @@ sendEvent: function(data as object, callback = _adb_default_callback as function
 > **Note**
 > Variables are not case sensitive in [BrightScript](https://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md), so always use the `String literals` to present the XDM data **keys**.
 
-##### Example: sendEvent
+##### Example: sendEvent with XDM data
 
 ```brightscript
   data = {
@@ -140,7 +140,16 @@ sendEvent: function(data as object, callback = _adb_default_callback as function
       "commerce": {
         .....
       }
-    },
+    }
+  }
+
+  m.aepSdk.sendEvent(data)
+```
+
+##### Example: sendEvent with non-XDM data
+
+```brightscript
+  data = {
     "data" : {
       "customKey" : "customValue"
     }

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -111,10 +111,10 @@ Sends an Experience event to Edge Network.
 ##### Syntax
 
 ```brightscript
-sendEvent: function(xdmData as object, callback = _adb_default_callback as function, context = invalid as dynamic) as void
+sendEvent: function(data as object, callback = _adb_default_callback as function, context = invalid as dynamic) as void
 ```
 
-- `@param data as object : xdm data following the XDM schema that is defined in the Schema Editor`
+- `@param data as object : xdm data following the XDM schema that is defined in the Schema Editor, and free form non xdm data`
 - `@param [optional] callback as function(context, result) : handle Edge response`
 - `@param [optional] context as dynamic : context to be passed to the callback function`
 
@@ -134,23 +134,38 @@ sendEvent: function(xdmData as object, callback = _adb_default_callback as funct
 ##### Example: sendEvent
 
 ```brightscript
-  m.aepSdk.sendEvent({
-    "eventType": "commerce.orderPlaced",
+  data = {
+    "xdm" : {
+      "eventType": "commerce.orderPlaced",
       "commerce": {
         .....
       }
-  })
+    },
+    "data" : {
+      "customKey" : "customValue"
+    }
+  }
+
+  m.aepSdk.sendEvent(data)
 ```
 
 ##### Example: sendEvent with callback
 
 ```brightscript
-  m.aepSdk.sendEvent({
+  data = {
+    "xdm" : {
       "eventType": "commerce.orderPlaced",
       "commerce": {
         .....
       }
-  }, sub(context, result)
+    },
+    "data" : {
+      "customKey" : "customValue"
+    }
+  }
+
+
+  m.aepSdk.sendEvent(data, sub(context, result)
       print "callback result: "
       print result
       print context
@@ -192,13 +207,23 @@ customIdentityMap = {
 ```
 
 ```brightscript
-  m.aepSdk.sendEvent({
-    "eventType": "commerce.orderPlaced",
+  data = {
+    "xdm" : {
+      "eventType": "commerce.orderPlaced",
       "commerce": {
         .....
       },
+
       "identityMap": customIdentityMap
-  })
+    },
+
+    "data" : {
+      "customKey" : "customValue"
+    }
+  }
+
+
+  m.aepSdk.sendEvent(data)
 ```
 ---
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -45,13 +45,16 @@ Initialize and configure the AEP Roku SDK inside your `scene` script.
   m.aepSdk.setLogLevel(ADB_CONSTANTS.LOG_LEVEL.DEBUG)
 
   ' send XDM data to Adobe Edge Network '
-
-  m.aepSdk.sendEvent({
-    "eventType": "commerce.orderPlaced",
-    "eventType": {
-      "key": "value"
+  data = {
+    "xdm": {
+      "eventType": "commerce.orderPlaced",
+      "eventType": {
+        "key": "value"
+      }
     }
-  })
+  }
+
+  m.aepSdk.sendEvent(data)
 ```
 
 > **Note**

--- a/code/AEPSDK.brs
+++ b/code/AEPSDK.brs
@@ -217,7 +217,12 @@ function AdobeAEPSDKInit(taskNode = invalid as dynamic) as object
                 return
             end if
 
-            ' event data: { "xdm": xdmData, "data" : data }
+            if data.data <> invalid and _adb_isEmptyOrInvalidMap(data.data) then
+                _adb_logError("sendEvent() - Cannot send event, invalid value for key:data (free-form data), must be a dictionary.")
+                return
+            end if
+
+            ' event data: { "xdm": xdmData, "data" : nonXdmdata }
             ' add a timestamp to the XDM data
             data.xdm.timestamp = _adb_ISO8601_timestamp()
             event = _adb_RequestEvent(m._private.cons.PUBLIC_API.SEND_EDGE_EVENT, data)

--- a/code/AEPSDK.brs
+++ b/code/AEPSDK.brs
@@ -203,24 +203,24 @@ function AdobeAEPSDKInit(taskNode = invalid as dynamic) as object
         '
         ' This function allows passing custom identifiers using identityMap.
         '
-        ' @param data as object : xdm data
+        ' @param data as object : Dictionary containg xdm and freeform data
         ' @param [optional] callback as function(context, result) : handle Edge response
         ' @param [optional] context as dynamic : context to be passed to the callback function
         '
         ' *************************************************************************************
 
-        sendEvent: function(xdmData as object, callback = _adb_defaultCallback as function, context = invalid as dynamic) as void
+        sendEvent: function(data as object, callback = _adb_defaultCallback as function, context = invalid as dynamic) as void
             _adb_logDebug("API: sendEvent()")
-            if _adb_isEmptyOrInvalidMap(xdmData) then
-                _adb_logError("sendEvent() - Cannot send event, invalid XDM data")
+
+            if _adb_isEmptyOrInvalidMap(data.xdm) then
+                _adb_logError("sendEvent() - Cannot send event, XDM data not found.")
                 return
             end if
-            ' event data: { "xdm": xdmData }
+
+            ' event data: { "xdm": xdmData, "data" : data }
             ' add a timestamp to the XDM data
-            xdmData.timestamp = _adb_ISO8601_timestamp()
-            event = _adb_RequestEvent(m._private.cons.PUBLIC_API.SEND_EDGE_EVENT, {
-                xdm: xdmData,
-            })
+            data.xdm.timestamp = _adb_ISO8601_timestamp()
+            event = _adb_RequestEvent(m._private.cons.PUBLIC_API.SEND_EDGE_EVENT, data)
 
             ' event.data.xdm.timestamp = event.getISOTimestamp()
             if callback <> _adb_defaultCallback then

--- a/code/AEPSDK.brs
+++ b/code/AEPSDK.brs
@@ -203,7 +203,7 @@ function AdobeAEPSDKInit(taskNode = invalid as dynamic) as object
         '
         ' This function allows passing custom identifiers using identityMap.
         '
-        ' @param data as object : Dictionary containg xdm and freeform data
+        ' @param data as object : Dictionary containing XDM and/or free-form data
         ' @param [optional] callback as function(context, result) : handle Edge response
         ' @param [optional] context as dynamic : context to be passed to the callback function
         '

--- a/code/tests/test_public_APIs.brs
+++ b/code/tests/test_public_APIs.brs
@@ -105,19 +105,63 @@ end sub
 sub TC_APIs_sendEvent()
     _internal_const = _adb_InternalConstants()
     sdkInstance = AdobeAEPSDKInit()
-    xdmData = {
-        eventType: "commerce.orderPlaced",
-        commerce: {
-    } }
+
+    data = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        }
+    }
+
     sdkInstance.sendEvent(xdmData)
+
     event = GetGlobalAA()._adb_main_task_node["requestEvent"]
-    UTF_assertEqual(event.apiName, _internal_const.PUBLIC_API.SEND_EDGE_EVENT)
-    UTF_assertEqual(sdkInstance._private.cachedCallbackInfo.Count(), 0)
-    UTF_assertEqual(event.data, { xdm: {
+    expectedData = {
+        "xdm" : {
             eventType: "commerce.orderPlaced",
             timestamp: event.timestamp,
-            commerce: {
-    } } })
+            commerce: {}
+        }
+    }
+
+    UTF_assertEqual(event.apiName, _internal_const.PUBLIC_API.SEND_EDGE_EVENT)
+    UTF_assertEqual(sdkInstance._private.cachedCallbackInfo.Count(), 0)
+    UTF_assertEqual(event.data, expectedData)
+    UTF_AssertNotInvalid(event.uuid)
+    UTF_AssertNotInvalid(event.timestamp)
+end sub
+
+sub TC_APIs_sendEventWithData()
+    _internal_const = _adb_InternalConstants()
+    sdkInstance = AdobeAEPSDKInit()
+
+    data = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        }
+        "data" : {
+            "testKey": "testValue"
+        }
+    }
+
+    sdkInstance.sendEvent(xdmData)
+
+    event = GetGlobalAA()._adb_main_task_node["requestEvent"]
+    expectedData = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            timestamp: event.timestamp,
+            commerce: {}
+        },
+        "data" : {
+            "testKey": "testValue"
+        }
+    }
+
+    UTF_assertEqual(event.apiName, _internal_const.PUBLIC_API.SEND_EDGE_EVENT)
+    UTF_assertEqual(sdkInstance._private.cachedCallbackInfo.Count(), 0)
+    UTF_assertEqual(event.data, expectedData)
     UTF_AssertNotInvalid(event.uuid)
     UTF_AssertNotInvalid(event.timestamp)
 end sub
@@ -136,20 +180,47 @@ end sub
 
 ' target: sendEvent()
 ' @Test
+sub TC_APIs_sendEvent_missingRequiredXDMData()
+    sdkInstance = AdobeAEPSDKInit()
+    data = {
+        "data" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        }
+    }
+
+    sdkInstance.sendEvent(data)
+
+    event = GetGlobalAA()._adb_main_task_node["requestEvent"]
+
+    UTF_assertEqual(0, event.Count())
+
+    UTF_assertEqual(sdkInstance._private.cachedCallbackInfo.Count(), 0)
+end sub
+
+' target: sendEvent()
+' @Test
 sub TC_APIs_sendEventWithCallback()
     sdkInstance = AdobeAEPSDKInit()
 
-    xdmData = {
-        eventType: "commerce.orderPlaced",
-        commerce: {
-    } }
+    data = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        },
+        "data" : {
+            "testKey": "testValue"
+        }
+    }
+
     context = {
         content: "test"
     }
     callback_result = {
         "test": "test"
     }
-    sdkInstance.sendEvent(xdmData, sub(ctx, result)
+
+    sdkInstance.sendEvent(xdm, sub(ctx, result)
         UTF_assertEqual({
             content: "test"
         }, ctx)
@@ -165,7 +236,7 @@ sub TC_APIs_sendEventWithCallback()
     UTF_AssertNotInvalid(callbackInfo.timestampInMillis)
     callbackInfo.cb(context, callback_result)
     UTF_assertEqual(event.apiName, "sendEvent")
-    UTF_assertEqual(event.data, { xdm: xdmData })
+    UTF_assertEqual(event.data, data)
     UTF_AssertNotInvalid(event.uuid)
     UTF_AssertNotInvalid(event.timestamp)
 end sub
@@ -175,17 +246,24 @@ end sub
 sub TC_APIs_sendEventWithCallback_timeout()
     sdkInstance = AdobeAEPSDKInit()
 
-    xdmData = {
-        eventType: "commerce.orderPlaced",
-        commerce: {
-    } }
+    data = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        },
+        "data" : {
+            "testKey": "testValue"
+        }
+    }
+
     context = {
         content: "test"
     }
     _callback_result = {
         "test": "test"
     }
-    sdkInstance.sendEvent(xdmData, sub(_ctx, _result)
+
+    sdkInstance.sendEvent(data, sub(_ctx, _result)
         throw "should not be called"
     end sub, context)
 
@@ -196,7 +274,7 @@ sub TC_APIs_sendEventWithCallback_timeout()
     UTF_AssertNotInvalid(callbackInfo.timestampInMillis)
 
     UTF_assertEqual(event.apiName, "sendEvent")
-    UTF_assertEqual(event.data, { xdm: xdmData })
+    UTF_assertEqual(event.data, data)
     UTF_AssertNotInvalid(event.uuid)
     UTF_AssertNotInvalid(event.timestamp)
     requestId = event.uuid

--- a/code/tests/test_public_APIs.brs
+++ b/code/tests/test_public_APIs.brs
@@ -113,7 +113,7 @@ sub TC_APIs_sendEvent()
         }
     }
 
-    sdkInstance.sendEvent(xdmData)
+    sdkInstance.sendEvent(data)
 
     event = GetGlobalAA()._adb_main_task_node["requestEvent"]
     expectedData = {
@@ -145,7 +145,7 @@ sub TC_APIs_sendEventWithData()
         }
     }
 
-    sdkInstance.sendEvent(xdmData)
+    sdkInstance.sendEvent(data)
 
     event = GetGlobalAA()._adb_main_task_node["requestEvent"]
     expectedData = {
@@ -171,6 +171,27 @@ end sub
 sub TC_APIs_sendEvent_invalid()
     sdkInstance = AdobeAEPSDKInit()
     sdkInstance.sendEvent("invalid xdm data")
+    event = GetGlobalAA()._adb_main_task_node["requestEvent"]
+
+    UTF_assertEqual(0, event.Count())
+
+    UTF_assertEqual(sdkInstance._private.cachedCallbackInfo.Count(), 0)
+end sub
+
+' target: sendEvent()
+' @Test
+sub TC_APIs_sendEventWithData_invalidData()
+    sdkInstance = AdobeAEPSDKInit()
+
+    data = {
+        "xdm" : {
+            eventType: "commerce.orderPlaced",
+            commerce: {}
+        }
+        "data" : "Not a map"
+    }
+
+    sdkInstance.sendEvent(data)
     event = GetGlobalAA()._adb_main_task_node["requestEvent"]
 
     UTF_assertEqual(0, event.Count())
@@ -220,7 +241,7 @@ sub TC_APIs_sendEventWithCallback()
         "test": "test"
     }
 
-    sdkInstance.sendEvent(xdm, sub(ctx, result)
+    sdkInstance.sendEvent(data, sub(ctx, result)
         UTF_assertEqual({
             content: "test"
         }, ctx)

--- a/sample/development/components/MainScene.brs
+++ b/sample/development/components/MainScene.brs
@@ -75,21 +75,25 @@ sub _sendEventWithCallback()
   ' Send an Experience Event with callback
   '----------------------------------------
 
-  m.aepSdk.sendEvent({
-    "eventType": "commerce.orderPlaced",
-    "commerce": {
-      "key3": "value3"
-    },
-    "identityMap": {
-      "RIDA": [
-        {
-          "id": "SampleAdId",
-          "authenticatedState": "ambiguous",
-          "primary": false
-        }
-      ]
+  data = {
+    "xdm":{
+      "eventType": "commerce.orderPlaced",
+      "commerce": {
+        "key3": "value3"
+      },
+      "identityMap": {
+        "RIDA": [
+          {
+            "id": "SampleAdId",
+            "authenticatedState": "ambiguous",
+            "primary": false
+          }
+        ]
+      }
     }
-  }, sub(context, result)
+  }
+
+  m.aepSdk.sendEvent(data, sub(context, result)
     jsonObj = ParseJson(result.message)
     message = _extractLocationHint(jsonObj, "Not found locationHint")
     ' show result in dialog
@@ -119,13 +123,16 @@ sub _testShutdownAPI()
 
   counter = 0
   while counter < 20
-    m.aepSdk.sendEvent({
-      "eventType": "commerce.orderPlaced",
-      "commerce": {
-        "key1": "value1",
-        "counter": counter
+    data = {
+      "xdm": {
+        "eventType": "commerce.orderPlaced",
+        "commerce": {
+          "key1": "value1",
+          "counter": counter
+        }
       }
-    })
+    }
+    m.aepSdk.sendEvent(data)
     counter++
   end while
 
@@ -271,12 +278,15 @@ sub timerExecutor()
     end if
     m.aepSdk_2.updateConfiguration(configuration)
 
-    m.aepSdk_2.sendEvent({
-      "eventType": "commerce.orderPlaced",
-      "commerce": {
-        "key3": "value3"
+    addToCartData = {
+      "xdm": {
+        "eventType": "commerce.addedToCart",
+        "commerce": {
+          "key3": "value3"
+        }
       }
-    }, sub(context, result)
+    }
+    m.aepSdk_2.sendEvent(addToCartData, sub(context, result)
       jsonObj = ParseJson(result.message)
       message = ""
       for each item in jsonObj.handle

--- a/sample/development/components/Screens/BottomGroup.brs
+++ b/sample/development/components/Screens/BottomGroup.brs
@@ -29,21 +29,24 @@ sub _initSDK()
 end sub
 
 sub onButtonSelected()
-    m.aepSdk.sendEvent({
-        "eventType": "commerce.orderPlaced",
-        "commerce": {
-            "key3": "value3"
-        },
-        "identityMap": {
-            "RIDA": [
-                {
-                    "id": "SampleAdId",
-                    "authenticatedState": "ambiguous",
-                    "primary": false
-                }
-            ]
+    orderPlacedData = {
+        "xdm": {
+            "eventType": "commerce.orderPlaced",
+            "commerce": {
+                "key3": "value3"
+            },
+            "identityMap": {
+                "RIDA": [
+                    {
+                        "id": "SampleAdId",
+                        "authenticatedState": "ambiguous",
+                        "primary": false
+                    }
+                ]
+            }
         }
-    }, sub(context, result)
+    }
+    m.aepSdk.sendEvent(orderPlacedData, sub(context, result)
         ' print "callback result: "
         ' print result
         ' print context

--- a/sample/development/components/Screens/NewScreen.brs
+++ b/sample/development/components/Screens/NewScreen.brs
@@ -36,21 +36,24 @@ sub _initSDK()
 end sub
 
 sub onButtonSelected()
-    m.aepSdk.sendEvent({
-        "eventType": "commerce.orderPlaced",
-        "commerce": {
-            "key3": "value3"
-        },
-        "identityMap": {
-            "RIDA": [
-                {
-                    "id": "SampleAdId",
-                    "authenticatedState": "ambiguous",
-                    "primary": false
-                }
-            ]
+    orderPlacedData = {
+        "xdm": {
+            "eventType": "commerce.orderPlaced",
+            "commerce": {
+                "key3": "value3"
+            },
+            "identityMap": {
+                "RIDA": [
+                    {
+                        "id": "SampleAdId",
+                        "authenticatedState": "ambiguous",
+                        "primary": false
+                    }
+                ]
+            }
         }
-    }, sub(context, result)
+    }
+    m.aepSdk.sendEvent(orderPlacedData, sub(context, result)
         ' print "callback result: "
         ' print result
         ' print context

--- a/sample/development/components/integration/test/integrationTests.brs
+++ b/sample/development/components/integration/test/integrationTests.brs
@@ -164,7 +164,16 @@ function TS_SDK_integration() as object
                 ]
             }
 
-            aepSdk.sendEvent({ key: "value", "identityMap": idMap })
+            data = {
+                "xdm": {
+                    key: "value",
+                    "identityMap": idMap
+                },
+                "data": {
+                    "testKey": "testValue"
+                }
+            }
+            aepSdk.sendEvent(data)
 
             eventIdForSendEvent = aepSdk._private.lastEventId
 
@@ -232,10 +241,20 @@ function TS_SDK_integration() as object
 
             aepSdk = ADB_retrieveSDKInstance()
 
-            aepSdk.sendEvent({ key: "value1" })
+            data1 = {
+                "xdm": {
+                    key: "value1"
+                }
+            }
+            aepSdk.sendEvent(data1)
             eventIdForFirstSendEvent = aepSdk._private.lastEventId
 
-            aepSdk.sendEvent({ key: "value2" })
+            data2 = {
+                "xdm": {
+                    key: "value2"
+                }
+            }
+            aepSdk.sendEvent(data2)
             eventIdForSecondSendEvent = aepSdk._private.lastEventId
 
             validator = {}
@@ -267,10 +286,20 @@ function TS_SDK_integration() as object
 
             aepSdk = ADB_retrieveSDKInstance()
 
-            aepSdk.sendEvent({ key: "value1" })
+            data1 = {
+                "xdm": {
+                    key: "value1"
+                }
+            }
+            aepSdk.sendEvent(data1)
             eventIdForFirstSendEvent = aepSdk._private.lastEventId
 
-            aepSdk.sendEvent({ key: "value2" })
+            data2 = {
+                "xdm": {
+                    key: "value2"
+                }
+            }
+            aepSdk.sendEvent(data2)
             eventIdForSecondSendEvent = aepSdk._private.lastEventId
 
             ADB_CONSTANTS = AdobeAEPSDKConstants()
@@ -280,7 +309,12 @@ function TS_SDK_integration() as object
 
             aepSdk.updateConfiguration(configuration)
 
-            aepSdk.sendEvent({ key: "value3" })
+            data3 = {
+                "xdm": {
+                    key: "value3"
+                }
+            }
+            aepSdk.sendEvent(data3)
             eventIdForThirdSendEvent = aepSdk._private.lastEventId
 
             validator = {}
@@ -356,7 +390,13 @@ function TS_SDK_integration() as object
             aepSdk.updateConfiguration(configuration)
 
             GetGlobalAA()._adb_integration_test_callback_result = invalid
-            aepSdk.sendEvent({ key: "value" }, sub(_context, result)
+
+            data = {
+                "xdm": {
+                    key: "value"
+                }
+            }
+            aepSdk.sendEvent(data, sub(_context, result)
                 GetGlobalAA()._adb_integration_test_callback_result = result
             end sub, {})
 
@@ -398,7 +438,12 @@ function TS_SDK_integration() as object
             aepSdk.updateConfiguration(configuration)
             eventIdForUpdateConfiguration = aepSdk._private.lastEventId
 
-            aepSdk.sendEvent({ key: "value" })
+            data = {
+                "xdm": {
+                    key: "value"
+                }
+            }
+            aepSdk.sendEvent(data)
 
             eventIdForSendEvent = aepSdk._private.lastEventId
 
@@ -449,7 +494,12 @@ function TS_SDK_integration() as object
             aepSdk.updateConfiguration(configuration)
             eventIdForUpdateConfiguration = aepSdk._private.lastEventId
 
-            aepSdk.sendEvent({ key: "value" })
+            data = {
+                "xdm": {
+                    key: "value"
+                }
+            }
+            aepSdk.sendEvent(data)
 
             eventIdForSendEvent = aepSdk._private.lastEventId
 

--- a/sample/simple-videoplayer-channel/components/MainScene.brs
+++ b/sample/simple-videoplayer-channel/components/MainScene.brs
@@ -67,21 +67,28 @@ sub _sendEventWithCallback()
   ' Send an Experience Event with callback
   '----------------------------------------
 
-  m.aepSdk.sendEvent({
-    "eventType": "commerce.orderPlaced",
-    "commerce": {
-      "key3": "value3"
-    },
-    "identityMap": {
-      "RIDA": [
-        {
-          "id": "SampleAdId",
-          "authenticatedState": "ambiguous",
-          "primary": false
+  m.aepSdk.sendEvent(
+    {
+      "xdm" : {
+        "eventType": "commerce.orderPlaced",
+        "commerce": {
+          "key3": "value3"
+        },
+        "identityMap": {
+          "RIDA": [
+            {
+              "id": "SampleAdId",
+              "authenticatedState": "ambiguous",
+              "primary": false
+            }
+          ]
         }
-      ]
-    }
-  }, sub(context, result)
+      },
+      ''' free form data
+      "data": {
+        "key" : "value"
+      }
+    }, sub(context, result)
     jsonObj = ParseJson(result.message)
     message = _extractLocationHint(jsonObj, "Not found locationHint")
     ' show result in dialog
@@ -111,13 +118,21 @@ sub _testShutdownAPI()
 
   counter = 0
   while counter < 20
-    m.aepSdk.sendEvent({
-      "eventType": "commerce.orderPlaced",
-      "commerce": {
-        "key1": "value1",
-        "counter": counter
+    m.aepSdk.sendEvent(
+      {
+        "xdm": {
+          "eventType": "commerce.orderPlaced",
+          "commerce": {
+            "key1": "value1",
+            "counter": counter
+          }
+        },
+        ''' free form data
+        "data": {
+          "key" : "value"
+        }
       }
-    })
+    )
     counter++
   end while
 

--- a/sample/simple-videoplayer-channel/components/Screens/BottomGroup.brs
+++ b/sample/simple-videoplayer-channel/components/Screens/BottomGroup.brs
@@ -29,21 +29,24 @@ sub _initSDK()
 end sub
 
 sub onButtonSelected()
-    m.aepSdk.sendEvent({
-        "eventType": "commerce.orderPlaced",
-        "commerce": {
-            "key3": "value3"
-        },
-        "identityMap": {
-            "RIDA": [
-                {
-                    "id": "SampleAdId",
-                    "authenticatedState": "ambiguous",
-                    "primary": false
-                }
-            ]
+    orderPlacedData = {
+        "xdm": {
+            "eventType": "commerce.orderPlaced",
+            "commerce": {
+                "key3": "value3"
+            },
+            "identityMap": {
+                "RIDA": [
+                    {
+                        "id": "SampleAdId",
+                        "authenticatedState": "ambiguous",
+                        "primary": false
+                    }
+                ]
+            }
         }
-    }, sub(_context, _result)
+    }
+    m.aepSdk.sendEvent(orderPlacedData, sub(_context, _result)
         ' print "callback result: "
         ' print result
         ' print context

--- a/sample/simple-videoplayer-channel/components/Screens/NewScreen.brs
+++ b/sample/simple-videoplayer-channel/components/Screens/NewScreen.brs
@@ -35,21 +35,24 @@ sub _initSDK()
 end sub
 
 sub onButtonSelected()
-    m.aepSdk.sendEvent({
-        "eventType": "commerce.orderPlaced",
-        "commerce": {
-            "key3": "value3"
-        },
-        "identityMap": {
-            "RIDA": [
-                {
-                    "id": "SampleAdId",
-                    "authenticatedState": "ambiguous",
-                    "primary": false
-                }
-            ]
+    orderPlacedData = {
+        "xdm": {
+            "eventType": "commerce.orderPlaced",
+            "commerce": {
+                "key3": "value3"
+            },
+            "identityMap": {
+                "RIDA": [
+                    {
+                        "id": "SampleAdId",
+                        "authenticatedState": "ambiguous",
+                        "primary": false
+                    }
+                ]
+            }
         }
-    }, sub(_context, _result)
+    }
+    m.aepSdk.sendEvent(orderPlacedData, sub(_context, _result)
         ' print "callback result: "
         ' print result
         ' print context


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As per the internal discussion we decided to make a breaking change and update `sendEvent` API to  accept the payload in a different format.

Current:
```
xdmData = {
   "key" : "value"
}

aepSDK.sendEvent(xdmData)
```

Updated
```
xdmData = {
   "key" : "value"
}

nonXdmData = {
  "customKey": "customValue"
}

xdmAndNonXdmData = {
   "xdm": xdmData,
   "data": nonXdmData
}

aepSDK.sendEvent(xdmAndNonXdmData)
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
