### PR TITLE
Cleanup to avoid confusion and get ready for the datastream override feature

### DIFF
--- a/code/main/edge/edgeModule.brs
+++ b/code/main/edge/edgeModule.brs
@@ -35,8 +35,8 @@ function _adb_EdgeModule(configurationModule as object, identityModule as object
         _identityModule: identityModule,
         _edgeRequestWorker: _adb_EdgeRequestWorker(),
 
-        processEvent: function(requestId as string, xdmData as object, timestampInMillis as longinteger) as dynamic
-            m._edgeRequestWorker.queue(requestId, [xdmData], timestampInMillis, {}, m._EDGE_REQUEST_PATH)
+        processEvent: function(requestId as string, eventData as object, timestampInMillis as longinteger) as dynamic
+            m._edgeRequestWorker.queue(requestId, eventData, timestampInMillis, {}, m._EDGE_REQUEST_PATH)
             return m.processQueuedRequests()
         end function,
 

--- a/code/main/task/eventProcessor.brs
+++ b/code/main/task/eventProcessor.brs
@@ -207,9 +207,9 @@ function _adb_EventProcessor(task as object) as object
             end if
 
             requestId = event.uuid
-            xdmData = event.data
+            eventData = event.data
             timestampInMillis = event.timestampInMillis
-            responseEvents = m._edgeModule.processEvent(requestId, xdmData, timestampInMillis)
+            responseEvents = m._edgeModule.processEvent(requestId, eventData, timestampInMillis)
 
             for each responseEvent in responseEvents
                 m._sendResponseEvent(responseEvent)

--- a/code/tests/edge/test_edgeModule.brs
+++ b/code/tests/edge/test_edgeModule.brs
@@ -46,7 +46,7 @@ sub TC_adb_EdgeModule_processEvent()
     queue = edgeModule._edgeRequestWorker._queue
     UTF_assertEqual(1, queue.Count())
     UTF_assertEqual("request_id", queue[0].requestId)
-    UTF_assertEqual({ key: "value" }, queue[0].xdmEvents[0])
+    UTF_assertEqual({ key: "value" }, queue[0].eventData)
     UTF_assertEqual(timestampInMillis&, queue[0].timestampInMillis)
 
     UTF_assertTrue(_adb_isArray(result))

--- a/code/tests/edge/test_edgeRequestWorker.brs
+++ b/code/tests/edge/test_edgeRequestWorker.brs
@@ -36,13 +36,13 @@ sub TC_adb_EdgeRequestWorker_queue()
     worker = _adb_EdgeRequestWorker()
     worker._queue = []
     timestampInMillis& = _adb_timestampInMillis()
-    worker.queue("request_id", [{ xdm: {} }], timestampInMillis&, {}, "/ee/v1/interact")
+    worker.queue("request_id", { xdm: {} }, timestampInMillis&, {}, "/ee/v1/interact")
     UTF_assertEqual(1, worker._queue.Count())
     expectedObj = {
         requestId: "request_id",
         meta: {},
         path: "/ee/v1/interact",
-        xdmEvents: [{ xdm: {} }],
+        eventData: { xdm: {} },
         timestampInMillis: timestampInMillis&
     }
     UTF_assertEqual(expectedObj, worker._queue[0])
@@ -69,9 +69,9 @@ sub TC_adb_EdgeRequestWorker_queue_limit()
     worker = _adb_EdgeRequestWorker()
     worker._queue = []
     worker._queue_size_max = 2
-    worker.queue("request_id", [{ xdm: {} }], 12345534, {}, "")
-    worker.queue("request_id", [{ xdm: {} }], 12345535, {}, "")
-    worker.queue("request_id", [{ xdm: {} }], 12345536, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345534, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345535, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345536, {}, "")
     UTF_assertEqual(2, worker._queue.Count())
 end sub
 
@@ -80,9 +80,9 @@ end sub
 sub TC_adb_EdgeRequestWorker_clear()
     worker = _adb_EdgeRequestWorker()
     worker._queue = []
-    worker.queue("request_id", [{ xdm: {} }], 12345534, {}, "")
-    worker.queue("request_id", [{ xdm: {} }], 12345535, {}, "")
-    worker.queue("request_id", [{ xdm: {} }], 12345536, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345534, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345535, {}, "")
+    worker.queue("request_id", { xdm: {} }, 12345536, {}, "")
     UTF_assertEqual(3, worker._queue.Count())
     worker.clear()
     UTF_assertEqual(0, worker._queue.Count())
@@ -127,7 +127,7 @@ sub TC_adb_EdgeRequestWorker_processRequest_valid_response()
     end function
 
     worker = _adb_EdgeRequestWorker()
-    networkResponse = worker._processRequest([{ xdm: { key: "value" } }], "ecid_test", "config_id", "request_id", "/ee/v1/interact", invalid)
+    networkResponse = worker._processRequest({ xdm: { key: "value" } }, "ecid_test", "config_id", "request_id", "/ee/v1/interact", invalid)
 
     UTF_assertEqual(200, networkResponse.getResponseCode())
     UTF_assertEqual("response body", networkResponse.getResponseString())
@@ -149,7 +149,7 @@ sub TC_adb_EdgeRequestWorker_processRequest_invalid_response()
     end function
 
     worker = _adb_EdgeRequestWorker()
-    result = worker._processRequest([{ xdm: { key: "value" } }], "ecid_test", "config_id", "request_id", "/ee/v1/interact", invalid)
+    result = worker._processRequest({ xdm: { key: "value" } }, "ecid_test", "config_id", "request_id", "/ee/v1/interact", invalid)
 
     UTF_assertInvalid(result)
 
@@ -173,8 +173,8 @@ sub TC_adb_EdgeRequestWorker_processRequests()
     end function
 
     worker = _adb_EdgeRequestWorker()
-    worker.queue("request_id_1", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
-    worker.queue("request_id_2", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_1", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_2", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
 
     responseArray = worker.processRequests("config_id", "ecid_test")
     ' processRequests: function(configId as string, ecid as string, edgeDomain = invalid as dynamic) as dynamic
@@ -227,9 +227,9 @@ sub TC_adb_EdgeRequestWorker_processRequests_recoverableError_retriesAfterWaitTi
 
     worker = _adb_EdgeRequestWorker()
 
-    worker.queue("request_id_1", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
-    worker.queue("request_id_2", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
-    worker.queue("request_id_3", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_1", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_2", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_3", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
     responseArray = worker.processRequests("config_id", "ecid_test")
 
     UTF_assertEqual(1, responseArray.Count())
@@ -296,9 +296,9 @@ sub TC_adb_EdgeRequestWorker_queue_newRequest_after_RecoverableError_retriesImme
 
     worker = _adb_EdgeRequestWorker()
 
-    worker.queue("request_id_1", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
-    worker.queue("request_id_2", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
-    worker.queue("request_id_3", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_1", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_2", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_3", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
     responseArray = worker.processRequests("config_id", "ecid_test")
 
     UTF_assertEqual(1, responseArray.Count())
@@ -320,7 +320,7 @@ sub TC_adb_EdgeRequestWorker_queue_newRequest_after_RecoverableError_retriesImme
     end function
 
     ' Request should be not be sent since < 30 seconds
-    worker.queue("request_id_4", [{ xdm: { key: "value" } }], 12345534, {}, "/ee/v1/interact")
+    worker.queue("request_id_4", { xdm: { key: "value" } }, 12345534, {}, "/ee/v1/interact")
     UTF_assertEqual(-1, worker._lastFailedRequestTS, "Failed Request TS should be reset to -1")
 
     responseArray = worker.processRequests("config_id", "ecid_test")


### PR DESCRIPTION
- Rename xdmData to eventData since now that contains xdm as well as freeform/non-xdm data and will also contain datastream override details in future.
- Converting to list of xdm events in edgeRequestWorker where we create the payload.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
