### PR TITLE
Add Consent Module - Setup + Configuration + Unit tests

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -36,12 +36,13 @@ cat ./code/AEPSDK.brs > ./output/AEPSDK.brs
 
 core_array=(`find ./code/main/core -maxdepth 2 -name "*.brs"`)
 edge_array=(`find ./code/main/edge -maxdepth 2 -name "*.brs"`)
+consent_array=(`find ./code/main/consent -maxdepth 2 -name "*.brs"`)
 task_array=(`find ./code/main/task -maxdepth 2 -name "*.brs"`)
 services_array=(`find ./code/main/services -maxdepth 2 -name "*.brs"`)
 common_array=(`find ./code/main/common -maxdepth 2 -name "*.brs"`)
 media_array=(`find ./code/main/media -maxdepth 2 -name "*.brs"`)
 
-brs_array=("${core_array[@]}" "${edge_array[@]}" "${task_array[@]}" "${services_array[@]}" "${common_array[@]}" "${media_array[@]}")
+brs_array=("${core_array[@]}" "${edge_array[@]}" "${consent_array[@]}" "${task_array[@]}" "${services_array[@]}" "${common_array[@]}" "${media_array[@]}")
 
 unordered_brs_array=(`find ./code/main -maxdepth 2 -name "*.brs"`)
 

--- a/code/AEPSDK.brs
+++ b/code/AEPSDK.brs
@@ -20,6 +20,7 @@ function AdobeAEPSDKConstants() as object
         CONFIGURATION: {
             EDGE_CONFIG_ID: "edge.configId",
             EDGE_DOMAIN: "edge.domain",
+            CONSENT_DEFAULT: "consent.default",
             MEDIA_CHANNEL: "edgemedia.channel",
             MEDIA_PLAYER_NAME: "edgemedia.playerName",
             MEDIA_APP_VERSION: "edgemedia.appVersion",

--- a/code/main/consent/consentModule.brs
+++ b/code/main/consent/consentModule.brs
@@ -47,7 +47,8 @@ function _adb_ConsentModule(configurationModule as object) as object
             return "y"
         end function,
 
-        _extractConsentFromConfiguration: function() as dynamic
+        ''' usage: collectConsent = m._extractCollectConsentValue(m._configurationModule.getConsent())
+        _extractCollectConsentValue: function(consentMap as object) as dynamic
             consentConfig = m._configurationModule.getDefaultConsent()
 
             if _adb_isEmptyOrInvalidMap(consentConfig) then
@@ -106,4 +107,3 @@ function _adb_ConsentModule(configurationModule as object) as object
     })
     return module
 end function
-

--- a/code/main/consent/consentModule.brs
+++ b/code/main/consent/consentModule.brs
@@ -49,18 +49,16 @@ function _adb_ConsentModule(configurationModule as object) as object
 
         ''' usage: collectConsent = m._extractCollectConsentValue(m._configurationModule.getConsent())
         _extractCollectConsentValue: function(consentMap as object) as dynamic
-            consentConfig = m._configurationModule.getDefaultConsent()
-
-            if _adb_isEmptyOrInvalidMap(consentConfig) then
+            if _adb_isEmptyOrInvalidMap(consentMap) then
                 return invalid
             end if
 
-            consentList = consentConfig["consents"]
-            if _adb_isEmptyOrInvalidMap(consentList) then
+            consents = consentMap["consents"]
+            if _adb_isEmptyOrInvalidMap(consents) then
                 return invalid
             end if
 
-            collectConsent = consentList["collect"]
+            collectConsent = consents["collect"]
             if _adb_isEmptyOrInvalidMap(collectConsent) then
                 return invalid
             end if

--- a/code/main/consent/consentModule.brs
+++ b/code/main/consent/consentModule.brs
@@ -1,0 +1,109 @@
+' ********************** Copyright 2024 Adobe. All rights reserved. **********************
+' *
+' * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+' * you may not use this file except in compliance with the License. You may obtain a copy
+' * of the License at http://www.apache.org/licenses/LICENSE-2.0
+' *
+' * Unless required by applicable law or agreed to in writing, software distributed under
+' * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+' * OF ANY KIND, either express or implied. See the License for the specific language
+' * governing permissions and limitations under the License.
+' *
+' *****************************************************************************************
+
+' ************************************ MODULE: Consent ***************************************
+
+function _adb_isConsentModule(module as object) as boolean
+    return (module <> invalid and module.type = "com.adobe.module.consent")
+end function
+
+function _adb_ConsentModule(configurationModule as object) as object
+    if not _adb_isConfigurationModule(configurationModule) then
+        _adb_logError("ConsentModule::_adb_ConsentModule() - configurationModule is not valid.")
+        return invalid
+    end if
+
+    module = _adb_AdobeObject("com.adobe.module.consent")
+    module.Append({
+        ''' TODO: Update the path
+        _CONSENT_REQUEST_PATH: "/ee/v1/interact",
+        _configurationModule: configurationModule,
+        _collectConsent: invalid,
+
+        ''' TODO
+        setConsent: function(consent as object) as void
+            ''' Send the consent update request to Edge
+            ''' Update the collect consent in persistence based on the edge request response
+        end function,
+
+        ''' TODO
+        _getCollectConsent: function() as string
+            ''' TODO:
+            ''' check if consent is udpated and persisted and use that value
+            ''' if not, get the default value from the configuration
+            ''' if both not available, return 'y'
+            ''' return y|p|n
+
+            return "y"
+        end function,
+
+        _extractConsentFromConfiguration: function() as dynamic
+            consentConfig = m._configurationModule.getDefaultConsent()
+
+            if _adb_isEmptyOrInvalidMap(consentConfig) then
+                return invalid
+            end if
+
+            consentList = consentConfig["consents"]
+            if _adb_isEmptyOrInvalidMap(consentList) then
+                return invalid
+            end if
+
+            collectConsent = consentList["collect"]
+            if _adb_isEmptyOrInvalidMap(collectConsent) then
+                return invalid
+            end if
+
+            collectConsentValue = collectConsent["val"]
+            if not m._isValidConsentValue(collectConsentValue) then
+                return invalid
+            end if
+
+            return collectConsentValue
+        end function,
+
+        _isValidConsentValue: function(consentValue as dynamic) as boolean
+            if _adb_isEmptyOrInvalidString(consentValue) then
+                return false
+            end if
+
+            return (consentValue = "y" or consentValue = "p" or consentValue = "n")
+        end function,
+
+        ''' TODO
+        _processConsentResponse: function(response as object) as void
+            ''' Process the response from Edge for the consent update request
+            ''' Update the collect consent in persistence based on the edge request response
+        end function,
+
+        ''' TODO
+        _saveCollectConsent: function(consentValue as string) as void
+            ''' Save the collect consent in persistence
+            ''' y|p|n
+        end function,
+
+        ''' TODO
+        _getCollectConsentFromPersistence: function() as string
+            ''' Get the collect consent from persistence
+            ''' y|p|n
+        end function,
+
+        dump: function() as object
+            return {
+
+            }
+        end function
+    })
+    return module
+end function
+

--- a/code/main/core/configurationModule.brs
+++ b/code/main/core/configurationModule.brs
@@ -25,11 +25,15 @@ function _adb_ConfigurationModule() as object
         ' example: {"edge.configId":"1234567890", "edge.domain":"xyz.net"}
         _edge_configId: invalid,
         _edge_domain: invalid,
+        ' consent configuration
+        ' example: {"consent.default":{"consents":{"collect":{"val":"y"}}}}
+        _consent_default: invalid,
         ' media configuration
         ' example: {"edgemedia.channel":"channel_x", "edgemedia.playerName": "player_y", "edgemedia.appVersion": "1.0.0"}
         _media_channel: invalid,
         _media_playerName: invalid,
         _media_appVersion: invalid,
+
 
         updateConfiguration: function(configuration as object) as void
 
@@ -44,6 +48,12 @@ function _adb_ConfigurationModule() as object
             regexPattern = CreateObject("roRegex", "^((?!-)[A-Za-z0-9-]+(?<!-)\.)+[A-Za-z]{2,6}$", "")
             if not _adb_isEmptyOrInvalidString(domain) and regexPattern.isMatch(domain)
                 m._edge_domain = domain
+            end if
+
+            ' get the default consent map
+            defaultConsent = _adb_optMapFromMap(configuration, m._CONFIG_KEY.CONSENT_DEFAULT)
+            if not _adb_isEmptyOrInvalidMap(defaultConsent)
+                m._consent_default = defaultConsent
             end if
 
             ' update Media configuration
@@ -70,6 +80,10 @@ function _adb_ConfigurationModule() as object
             return m._edge_domain
         end function,
 
+        getDefaultConsent: function() as dynamic
+            return m._consent_default
+        end function,
+
         getMediaChannel: function() as dynamic
             return m._media_channel
         end function,
@@ -86,6 +100,7 @@ function _adb_ConfigurationModule() as object
             return {
                 edge_configId: m._edge_configId,
                 edge_domain: m._edge_domain,
+                consent_default: m._consent_default,
                 media_channel: m._media_channel,
                 media_playerName: m._media_playerName,
                 media_appVersion: m._media_appVersion

--- a/code/main/task/eventProcessor.brs
+++ b/code/main/task/eventProcessor.brs
@@ -20,12 +20,14 @@ function _adb_EventProcessor(task as object) as object
         _configurationModule: invalid,
         _identityModule: invalid,
         _edgeModule: invalid,
+        _consentModule: invalid,
         _mediaModule: invalid,
 
         init: function() as void
             m._configurationModule = _adb_ConfigurationModule()
             m._identityModule = _adb_IdentityModule(m._configurationModule)
             m._edgeModule = _adb_EdgeModule(m._configurationModule, m._identityModule)
+            m._consentModule = _adb_ConsentModule(m._configurationModule)
             m._mediaModule = _adb_MediaModule(m._configurationModule, m._edgeModule.createEdgeRequestQueue("MediaRequestQueue"))
 
             ' enable debug mode if needed
@@ -72,6 +74,7 @@ function _adb_EventProcessor(task as object) as object
             debugInfo["configuration"] = m._configurationModule.dump()
             debugInfo["identity"] = m._identityModule.dump()
             debugInfo["edge"] = m._edgeModule.dump()
+            debugInfo["consent"] = m._consentModule.dump()
             debugInfo["media"] = m._mediaModule.dump()
             debugInfo["networkRequests"] = networkService.dump()
 

--- a/code/tests/consent/test_consentModule.brs
+++ b/code/tests/consent/test_consentModule.brs
@@ -41,7 +41,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_valid()
     }
 
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertEqual("y", actualCollectConsent, "expected: y, actual: " + FormatJson(actualCollectConsent))
 
     configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
@@ -53,7 +53,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_valid()
     }
 
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertEqual("n", actualCollectConsent, "expected: n, actual: " + FormatJson(actualCollectConsent))
 
 
@@ -66,7 +66,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_valid()
     }
 
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertEqual("p", actualCollectConsent, "expected: p, actual: " + FormatJson(actualCollectConsent))
 end sub
 
@@ -84,13 +84,13 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
 
     ''' case 1 default consent is not present
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 
     ''' case 2 default consent is empty
     configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {}
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 
     ''' case 3 default consent does not have collect key
@@ -99,7 +99,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
         }
     }
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 
     ''' case 4 collect consent does not have val key
@@ -110,7 +110,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
         }
     }
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 
     ''' case 5 collect consent does not have val key
@@ -122,7 +122,7 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
         }
     }
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 
     ''' case 6 collect consent val is not valid
@@ -135,6 +135,6 @@ sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
     }
 
     configurationModule.updateConfiguration(configuration)
-    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    actualCollectConsent = consentModule._extractCollectConsentValue(configurationModule.getDefaultConsent())
     UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
 end sub

--- a/code/tests/consent/test_consentModule.brs
+++ b/code/tests/consent/test_consentModule.brs
@@ -1,0 +1,140 @@
+' ********************** Copyright 2024 Adobe. All rights reserved. **********************
+
+' This file is licensed to you under the Apache License, Version 2.0 (the "License");
+' you may not use this file except in compliance with the License. You may obtain a copy
+' of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+' Unless required by applicable law or agreed to in writing, software distributed under
+' the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+' OF ANY KIND, either express or implied. See the License for the specific language
+' governing permissions and limitations under the License.
+
+' *****************************************************************************************
+
+' target: _adb_ConsentModule()
+' @Test
+sub TC_adb_ConsentModule_init()
+    configurationModule = _adb_ConfigurationModule()
+    consentModule = _adb_ConsentModule(configurationModule)
+    UTF_assertTrue(_adb_isConsentModule(consentModule))
+
+    consentModule = _adb_ConsentModule(invalid)
+    UTF_assertInvalid(consentModule)
+end sub
+
+' target: _extractConsentFromConfiguration
+' @Test
+sub TC_adb_ConsentModule_extractConsentFromConfiguration_valid()
+
+    configurationModule = _adb_ConfigurationModule()
+    consentModule = _adb_ConsentModule(configurationModule)
+
+    ADB_CONSTANTS = AdobeAEPSDKConstants()
+
+    configuration = {}
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+                "val": "y"
+            }
+        }
+    }
+
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertEqual("y", actualCollectConsent, "expected: y, actual: " + FormatJson(actualCollectConsent))
+
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+                "val": "n"
+            }
+        }
+    }
+
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertEqual("n", actualCollectConsent, "expected: n, actual: " + FormatJson(actualCollectConsent))
+
+
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+                "val": "p"
+            }
+        }
+    }
+
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertEqual("p", actualCollectConsent, "expected: p, actual: " + FormatJson(actualCollectConsent))
+end sub
+
+
+' target: _extractConsentFromConfiguration
+' @Test
+sub TC_adb_ConsentModule_extractConsentFromConfiguration_invalid()
+
+    configurationModule = _adb_ConfigurationModule()
+    consentModule = _adb_ConsentModule(configurationModule)
+
+    ADB_CONSTANTS = AdobeAEPSDKConstants()
+
+    configuration = {}
+
+    ''' case 1 default consent is not present
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+
+    ''' case 2 default consent is empty
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {}
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+
+    ''' case 3 default consent does not have collect key
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+        }
+    }
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+
+    ''' case 4 collect consent does not have val key
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+            }
+        }
+    }
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+
+    ''' case 5 collect consent does not have val key
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+                "notVal": "y"
+            }
+        }
+    }
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+
+    ''' case 6 collect consent val is not valid
+    configuration[ADB_CONSTANTS.CONFIGURATION.CONSENT_DEFAULT] = {
+        "consents": {
+            "collect": {
+                "val": "pending"
+            }
+        }
+    }
+
+    configurationModule.updateConfiguration(configuration)
+    actualCollectConsent = consentModule._extractConsentFromConfiguration()
+    UTF_assertInvalid(actualCollectConsent, "expected: Invalid, actual: " + FormatJson(actualCollectConsent))
+end sub

--- a/code/tests/core/test_configurationModule.brs
+++ b/code/tests/core/test_configurationModule.brs
@@ -18,6 +18,10 @@ sub TC_adb_ConfigurationModule_init()
     configurationModule = _adb_ConfigurationModule()
     UTF_assertInvalid(configurationModule.getConfigId())
     UTF_assertInvalid(configurationModule.getEdgeDomain())
+    UTF_assertInvalid(configurationModule.getMediaChannel())
+    UTF_assertInvalid(configurationModule.getMediaPlayerName())
+    UTF_assertInvalid(configurationModule.getMediaAppVersion())
+    UTF_assertInvalid(configurationModule.getDefaultConsent())
 end sub
 
 ' target: adb_ConfigurationModule()
@@ -226,4 +230,44 @@ sub TC_adb_ConfigurationModule_invalidMediaConfig()
     UTF_assertEqual(configurationModule.getMediaChannel(), "testChannel")
     UTF_assertEqual(configurationModule.getMediaPlayerName(), "testPlayerName")
     UTF_assertEqual(configurationModule.getMediaAppVersion(), "1.1.0")
+end sub
+
+
+' target: adb_ConfigurationModule()
+' @Test
+sub TC_adb_ConfigurationModule_validConsentConfig()
+    configurationModule = _adb_ConfigurationModule()
+    config = {
+        "consent.default" : {
+            "consents": {
+                "collect": {
+                    "val": "y"
+                }
+            }
+        }
+    }
+
+    configurationModule.updateConfiguration(config)
+
+    expectedDefaultConsent = {
+        "consents": {
+            "collect": {
+                "val": "y"
+            }
+        }
+    }
+    UTF_assertEqual(configurationModule.getDefaultConsent(), expectedDefaultConsent)
+end sub
+
+' target: adb_ConfigurationModule()
+' @Test
+sub TC_adb_ConfigurationModule_invalidConsentConfig()
+    configurationModule = _adb_ConfigurationModule()
+    config = {
+        "consent.default" : "not a map"
+    }
+
+    configurationModule.updateConfiguration(config)
+
+    UTF_assertInvalid(configurationModule.getDefaultConsent())
 end sub

--- a/sample/development/Makefile
+++ b/sample/development/Makefile
@@ -6,6 +6,7 @@ link-sdk:
 	(ln -s ../../../../code/AEPSDK.brs ./source/adobe/AEPSDK.brs)
 	(ln -s ../../../../code/main/common ./source/adobe/common)
 	(ln -s ../../../../code/main/edge ./source/adobe/edge)
+	(ln -s ../../../../code/main/consent ./source/adobe/consent)
 	(ln -s ../../../../code/main/services ./source/adobe/services)
 	(ln -s ../../../../code/main/task ./source/adobe/task)
 	(ln -s ../../../../code/main/core ./source/adobe/core)

--- a/sample/development/source/setup_tests.brs
+++ b/sample/development/source/setup_tests.brs
@@ -133,6 +133,13 @@ function _adb_test_functions() as dynamic
         TC_adb_EdgeModule_processEvent
         TC_adb_EdgeModule_processQueuedRequests
     ]
+    consent = [
+        'test_consentModule.brs
+        TC_adb_ConsentModule_init
+        TC_adb_ConsentModule_extractConsentFromConfiguration_valid
+        TC_adb_ConsentModule_extractConsentFromConfiguration_invalid
+
+    ]
     media = [
         'test_mediaUtils.brs
         TC_adb_extractPlayheadFromMediaXDMData
@@ -268,6 +275,7 @@ function _adb_test_functions() as dynamic
     functionList.Append(common)
     functionList.Append(services)
     functionList.Append(core)
+    functionList.Append(consent)
     functionList.Append(edge)
     functionList.Append(media)
     functionList.Append(initSDK)

--- a/sample/development/source/setup_tests.brs
+++ b/sample/development/source/setup_tests.brs
@@ -85,6 +85,9 @@ function _adb_test_functions() as dynamic
         TC_adb_ConfigurationModule_overwrittingMediaConfig
         TC_adb_ConfigurationModule_emptyMediaConfig
         TC_adb_ConfigurationModule_invalidMediaConfig
+        TC_adb_ConfigurationModule_validConsentConfig
+        TC_adb_ConfigurationModule_invalidConsentConfig
+
         ' test_identityModule.brs
         TS_identityModule_BeforeEach
         TC_adb_IdentityModule_bad_init
@@ -138,7 +141,8 @@ function _adb_test_functions() as dynamic
         TC_adb_ConsentModule_init
         TC_adb_ConsentModule_extractConsentFromConfiguration_valid
         TC_adb_ConsentModule_extractConsentFromConfiguration_invalid
-
+        TC_adb_ConsentModule_isValidConsentValue_valid
+        TC_adb_ConsentModule_isValidConsentValue_invalid
     ]
     media = [
         'test_mediaUtils.brs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add new config constant to set and read default consent
- Create a new Consent Module
- Extract collect consent from config
- Add tests for consent module
- Updated scripts and few other places which needs to be updated when adding a new module

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
