### PR TITLE
Added logic to push resetIdentities event to all registered modules

### DIFF
--- a/code/main/edge/edgeModule.brs
+++ b/code/main/edge/edgeModule.brs
@@ -87,6 +87,11 @@ function _adb_EdgeModule(configurationModule as object, identityModule as object
             return responseEvents
         end function,
 
+        resetIdentities: function() as void
+            _adb_logVerbose("EdgeModule::resetIdentities() - Resetting identities.")
+            m._edgeResponseManager.handleResetIdentities()
+        end function,
+
         _getEdgeConfig: function() as object
             configId = m._configurationModule.getConfigId()
             if _adb_isEmptyOrInvalidString(configId)

--- a/code/main/edge/edgeResponseManager.brs
+++ b/code/main/edge/edgeResponseManager.brs
@@ -65,6 +65,12 @@ function _adb_EdgeResponseManager() as object
                 _adb_logError("EdgeResponseManager::_processResponseOnSuccess() - Failed to handle edge response: (" + FormatJson(responseString) + ")")
             end try
         end function
+
+        handleResetIdentities: function() as void
+            _adb_logVerbose("EdgeResponseManager::handleResetIdentities() - Resetting location hint and state store.")
+            m._locationHintManager._delete()
+            m._stateStoreManager._delete()
+        end function,
     }
 
 end function

--- a/code/main/edge/stateStoreManager.brs
+++ b/code/main/edge/stateStoreManager.brs
@@ -131,6 +131,13 @@ function _adb_StateStoreManager() as object
 
             return currentTimeInMillis > stateStoreEntry.expiryTS
         end function
+
+        _delete: function() as void
+            _adb_logVerbose("_adb_StateStoreManager::_delete() - Deleting stateStore object.")
+            m._stateStoreMap = {}
+            localDataStoreService = _adb_serviceProvider().localDataStoreService
+            localDataStoreService.removeValue(_adb_InternalConstants().LOCAL_DATA_STORE_KEYS.STATE_STORE)
+        end function
     }
 
     stateStoreManager._init()

--- a/code/main/task/eventProcessor.brs
+++ b/code/main/task/eventProcessor.brs
@@ -135,8 +135,6 @@ function _adb_EventProcessor(task as object) as object
             _adb_logInfo("EventProcessor::_resetIdentities() - Resetting persisted identities.")
 
             m._dispatchResetIdentitiesEvent()
-            'm._identityModule.resetIdentities()
-            ' Add handlers to each module and call those handlers from here.
         end function,
 
         _resetSDK: function(_event as object) as void

--- a/code/tests/edge/test_edgeResponseManager.brs
+++ b/code/tests/edge/test_edgeResponseManager.brs
@@ -129,3 +129,34 @@ sub TC_adb_EdgeResponseManager_processResponse_responseWithTypeNotHandled()
     UTF_assertFalse(GetGlobalAA().stateStoreManager_processStateStoreHandle_called, "stateStoreManager.processStateStoreHandle() was called.")
     UTF_assertFalse(GetGlobalAA().locationHintManager_processLocationHintHandle_called, "locationHintManager.processLocationHintHandle() was called.")
 end sub
+
+' target: _adb_edgeResponseManager_handleResetIdentities()
+' @Test
+sub TC_adb_EdgeResponseManager_handleResetIdentities()
+    edgeResponseManager = _adb_edgeResponseManager()
+
+    GetGlobalAA().locationHintManager_delete_called = false
+    GetGlobalAA().stateStoreManager_delete_called = false
+
+    ' mock state store manager
+    mockStateStoreManager = {
+        _delete: function() as void
+            GetGlobalAA().stateStoreManager_delete_called = true
+        end function
+    }
+
+    ' mock location hint manager
+    mockLocationHintManager = {
+        _delete: function() as void
+            GetGlobalAA().locationHintManager_delete_called = true
+        end function
+    }
+
+    edgeResponseManager._stateStoreManager = mockStateStoreManager
+    edgeResponseManager._locationHintManager = mockLocationHintManager
+
+    edgeResponseManager.handleResetIdentities()
+
+    UTF_assertTrue(GetGlobalAA().stateStoreManager_delete_called, "stateStoreManager._delete() was not called.")
+    UTF_assertTrue(GetGlobalAA().locationHintManager_delete_called, "locationHintManager._delete() was not called.")
+end sub

--- a/sample/development/source/setup_tests.brs
+++ b/sample/development/source/setup_tests.brs
@@ -160,6 +160,7 @@ function _adb_test_functions() as dynamic
         TC_adb_EdgeResponseManager_processResponse_validLocationHintResponse
         TC_adb_EdgeResponseManager_processResponse_validStateStoreResponse
         TC_adb_EdgeResponseManager_processResponse_responseWithTypeNotHandled
+        TC_adb_EdgeResponseManager_handleResetIdentities
         'test_stateStoreManager.brs
         TS_StateStoreManager_BeforeEach
         TC_adb_StateStoreManager_Init


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- ResetIdentities Event is now passed to registered module.
- LocationHint and state:store (edge module) need to be dropped along with the ECID (identity module)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
